### PR TITLE
Use JSONP instead of CORS to support IE

### DIFF
--- a/sparkart.js
+++ b/sparkart.js
@@ -420,6 +420,9 @@ Many methods rely on and use each other
 			url: url,
 			type: 'get',
 			crossDomain: true,
+			xhrFields: {
+                withCredentials: true
+            },
 			dataType: 'jsonp',
 			data: parameters
 		});

--- a/sparkart.js
+++ b/sparkart.js
@@ -412,20 +412,28 @@ Many methods rely on and use each other
 	// Lets us custom process errors, set default parameters, etc
 	Fanclub.prototype.request = function( url, method, parameters, callback ){
 
+		var dataType = 'json';
 		parameters = $.extend( {}, parameters );
 		parameters.key = this.key;
-		parameters._method = method;
+
+		// If this is IE, we'll try using JSONP instead
+		if( typeof XDomainRequest !== 'undefined' ){
+			parameters._method = method;
+			method = 'GET';
+			dataType = 'jsonp';
+		}
+
 		if( parameters.id ) delete parameters.id;
 
 		// Generate a jQuery AJAX request
 		var request = $.ajax({
 			url: url,
-			type: 'get',
+			type: method,
 			crossDomain: true,
 			xhrFields: {
-                withCredentials: true
-            },
-			dataType: 'jsonp',
+				withCredentials: true
+			},
+			dataType: dataType,
 			data: parameters
 		});
 

--- a/sparkart.js
+++ b/sparkart.js
@@ -303,7 +303,7 @@ Many methods rely on and use each other
 			$widgets.each( function( i, widget ){
 				fanclub.draw( $(widget), config, function(){
 					callback_counter++;
-					if( callback_counter === $widgets.length && callback ) callback(); 
+					if( callback_counter === $widgets.length && callback ) callback();
 				});
 			});
 			return;
@@ -412,17 +412,15 @@ Many methods rely on and use each other
 
 		parameters = $.extend( {}, parameters );
 		parameters.key = this.key;
+		parameters._method = method;
 		if( parameters.id ) delete parameters.id;
 
 		// Generate a jQuery AJAX request
 		var request = $.ajax({
 			url: url,
-			type: method,
+			type: 'get',
 			crossDomain: true,
-			xhrFields: {
-                withCredentials: true
-            },
-			dataType: 'json',
+			dataType: 'jsonp',
 			data: parameters
 		});
 

--- a/sparkart.js
+++ b/sparkart.js
@@ -167,8 +167,10 @@ Builds the fanclub and returns the new fanclub object
 			register: [ function( data ){
 
 				// determine if we need to show the username field
-				if( data.customer.username === null ) data.customer.username_required = true;
-				else data.customer.username_required === false;
+				if( data.customer ){
+					if( data.customer.username === null ) data.customer.username_required = true;
+					else data.customer.username_required === false;
+				}
 
 				return data;
 			} ]
@@ -430,7 +432,10 @@ Many methods rely on and use each other
 		// Bind to the AJAX request's deferred events
 		request
 			.done( function( data ){
-				if( callback ) callback( null, data );
+				if( callback ){
+					if( data.status === 'error' ) callback( data.messages );
+					else callback( null, data );
+				}
 			})
 			.fail( function( request ){
 				try {

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -420,6 +420,9 @@ Many methods rely on and use each other
 			url: url,
 			type: 'get',
 			crossDomain: true,
+			xhrFields: {
+                withCredentials: true
+            },
 			dataType: 'jsonp',
 			data: parameters
 		});

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -412,20 +412,28 @@ Many methods rely on and use each other
 	// Lets us custom process errors, set default parameters, etc
 	Fanclub.prototype.request = function( url, method, parameters, callback ){
 
+		var dataType = 'json';
 		parameters = $.extend( {}, parameters );
 		parameters.key = this.key;
-		parameters._method = method;
+
+		// If this is IE, we'll try using JSONP instead
+		if( typeof XDomainRequest !== 'undefined' ){
+			parameters._method = method;
+			method = 'GET';
+			dataType = 'jsonp';
+		}
+
 		if( parameters.id ) delete parameters.id;
 
 		// Generate a jQuery AJAX request
 		var request = $.ajax({
 			url: url,
-			type: 'get',
+			type: method,
 			crossDomain: true,
 			xhrFields: {
-                withCredentials: true
-            },
-			dataType: 'jsonp',
+				withCredentials: true
+			},
+			dataType: dataType,
 			data: parameters
 		});
 

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -303,7 +303,7 @@ Many methods rely on and use each other
 			$widgets.each( function( i, widget ){
 				fanclub.draw( $(widget), config, function(){
 					callback_counter++;
-					if( callback_counter === $widgets.length && callback ) callback(); 
+					if( callback_counter === $widgets.length && callback ) callback();
 				});
 			});
 			return;
@@ -412,17 +412,15 @@ Many methods rely on and use each other
 
 		parameters = $.extend( {}, parameters );
 		parameters.key = this.key;
+		parameters._method = method;
 		if( parameters.id ) delete parameters.id;
 
 		// Generate a jQuery AJAX request
 		var request = $.ajax({
 			url: url,
-			type: method,
+			type: 'get',
 			crossDomain: true,
-			xhrFields: {
-                withCredentials: true
-            },
-			dataType: 'json',
+			dataType: 'jsonp',
 			data: parameters
 		});
 

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -167,8 +167,10 @@ Builds the fanclub and returns the new fanclub object
 			register: [ function( data ){
 
 				// determine if we need to show the username field
-				if( data.customer.username === null ) data.customer.username_required = true;
-				else data.customer.username_required === false;
+				if( data.customer ){
+					if( data.customer.username === null ) data.customer.username_required = true;
+					else data.customer.username_required === false;
+				}
 
 				return data;
 			} ]
@@ -430,7 +432,10 @@ Many methods rely on and use each other
 		// Bind to the AJAX request's deferred events
 		request
 			.done( function( data ){
-				if( callback ) callback( null, data );
+				if( callback ){
+					if( data.status === 'error' ) callback( data.messages );
+					else callback( null, data );
+				}
 			})
 			.fail( function( request ){
 				try {


### PR DESCRIPTION
After discussing possible options with @Timo614 the most feasible solution to the lack of CORS support in IE 9 for today's UFC launch seems to be using JSONP for all requests. This allows us to continue accessing the API over HTTPS. JSONP doesn't work for POST requests however, so inspired by [Stripe](https://stripe.com/blog/stripejs-and-jsonp) @Timo614 is going to be writing middleware that converts GET requests that include a `_method=post` parameter to POST so that we minimize changes to the existing implementation, particularly on the frontend. This solution may have some undesirable security implications that we'll need to consider further.

The most sensitive data we are transferring presently are passwords that grant access to a forum and affiliate codes. Alternative solutions would most likely require the use of iframe's which may be a longer term solution but would require further development and testing that we probably cannot afford today. 

This pull request has what I think are the only necessary changes to support this implementation. Will need to test once the middleware is deployed for testing however.
