### PR TITLE
Format event link publish dates

### DIFF
--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -129,6 +129,11 @@ this.sparkart = {};
 			event: [ function( data ){
 				data.event.date = convertDate( data.event.date );
 				data.event.doors_open = convertDate( data.event.doors_open );
+                $( data.event.links ).each( function( i, link ){
+                    link.publish_start = convertDate( link.publish_start );
+                    link.publish_end = convertDate( link.publish_end );
+                    link.soldout = link.status === "Sold Out" ? true : false;
+                });
 				data.event.start = convertDate( data.event.start );
 				data.event.venue = convertAddress( data.event.venue );
 				return data;
@@ -137,6 +142,11 @@ this.sparkart = {};
 				$( data.events ).each( function( i, event ){
 					event.date = convertDate( event.date );
 					event.doors_open = convertDate( event.doors_open );
+                    $( event.links ).each( function( i, link ){
+                        link.publish_start = convertDate( link.publish_start );
+                        link.publish_end = convertDate( link.publish_end );
+                        link.soldout = link.status === "Sold Out" ? true : false;
+                    });
 					event.start = convertDate( event.start );
 					event.venue = convertAddress( event.venue );
 				});

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -129,11 +129,11 @@ this.sparkart = {};
 			event: [ function( data ){
 				data.event.date = convertDate( data.event.date );
 				data.event.doors_open = convertDate( data.event.doors_open );
-                $( data.event.links ).each( function( i, link ){
-                    link.publish_start = convertDate( link.publish_start );
-                    link.publish_end = convertDate( link.publish_end );
-                    link.soldout = link.status === "Sold Out" ? true : false;
-                });
+				$( data.event.links ).each( function( i, link ){
+					link.publish_start = convertDate( link.publish_start );
+					link.publish_end = convertDate( link.publish_end );
+					link.soldout = link.status === "Sold Out" ? true : false;
+				});
 				data.event.start = convertDate( data.event.start );
 				data.event.venue = convertAddress( data.event.venue );
 				return data;
@@ -142,11 +142,11 @@ this.sparkart = {};
 				$( data.events ).each( function( i, event ){
 					event.date = convertDate( event.date );
 					event.doors_open = convertDate( event.doors_open );
-                    $( event.links ).each( function( i, link ){
-                        link.publish_start = convertDate( link.publish_start );
-                        link.publish_end = convertDate( link.publish_end );
-                        link.soldout = link.status === "Sold Out" ? true : false;
-                    });
+					$( event.links ).each( function( i, link ){
+						link.publish_start = convertDate( link.publish_start );
+						link.publish_end = convertDate( link.publish_end );
+						link.soldout = link.status === "Sold Out" ? true : false;
+				});
 					event.start = convertDate( event.start );
 					event.venue = convertAddress( event.venue );
 				});

--- a/test/scripts/tests.js
+++ b/test/scripts/tests.js
@@ -106,7 +106,17 @@ var mock_responses = {
 					description: '',
 					doors_open: null,
 					id: 2,
-					links: null,
+					links: [
+						{
+							name: "Public Tickets",
+							status: "Show",
+							url: "http://www.ticketmaster.com",
+							host: "Ticketmaster",
+							password: null,
+							publish_start: "2013-04-05T00:00:00-0400",
+							publish_end: "2013-08-09T07:00:00-0400"
+						}
+					],
 					start: null,
 					timezone: 'America/New_York',
 					title: '',
@@ -498,24 +508,33 @@ describe( 'Fanclub', function(){
 
 				fanclub.logged_in = false;
 				fanclub.renderWidget( 'events', {}, function( err, html, response ){
-					assert( response.events[0].date.ampm === "AM", 'Accurate preprocessed ampm' );
-					assert( response.events[0].date.day.text === "Sunday", 'Accurate preprocessed day.text' );
-					assert( response.events[0].date.day.abbr === "Sun", 'Accurate preprocessed day.abbr' );
-					assert( response.events[0].date.day.number === 10, 'Accurate preprocessed day.number' );
-					assert( response.events[0].date.hour.full === 0, 'Accurate preprocessed hour.full' );
-					assert( response.events[0].date.hour.half === 12, 'Accurate preprocessed hour.half' );
-					assert( response.events[0].date.minute === "00", 'Accurate preprocessed minute' );
-					assert( response.events[0].date.month.abbr === "Feb", 'Accurate preprocessed month.abbr' );
-					assert( response.events[0].date.month.text === "February", 'Accurate preprocessed month.text' );
-					assert( response.events[0].date.month.number === 2, 'Accurate preprocessed month.number' );
-					assert( response.events[0].date.original === "2013-02-10T00:00:00-0500", 'Accurate preprocessed original' );
-					assert( response.events[0].date.second === "00", 'Accurate preprocessed second' );
-					assert( response.events[0].date.timezone_offset === "-0500", 'Accurate preprocessed timezone_offset' );
-					assert( response.events[0].date.year.full === "2013", 'Accurate preprocessed year.full' );
-					assert( response.events[0].date.year.half === "13", 'Accurate preprocessed year.half' );
-
 					assert( !!html, 'HTML is not blank' );
 					assert( !err, 'There are no errors' );
+
+					// Testing ALL fields for #convertDate()
+					var response_date = response.events[0].date;
+					assert( response_date.ampm === "AM", 'Accurate preprocessed ampm' );
+					assert( response_date.day.text === "Sunday", 'Accurate preprocessed day.text' );
+					assert( response_date.day.abbr === "Sun", 'Accurate preprocessed day.abbr' );
+					assert( response_date.day.number === 10, 'Accurate preprocessed day.number' );
+					assert( response_date.hour.full === 0, 'Accurate preprocessed hour.full' );
+					assert( response_date.hour.half === 12, 'Accurate preprocessed hour.half' );
+					assert( response_date.minute === "00", 'Accurate preprocessed minute' );
+					assert( response_date.month.abbr === "Feb", 'Accurate preprocessed month.abbr' );
+					assert( response_date.month.text === "February", 'Accurate preprocessed month.text' );
+					assert( response_date.month.number === 2, 'Accurate preprocessed month.number' );
+					assert( response_date.original === "2013-02-10T00:00:00-0500", 'Accurate preprocessed original' );
+					assert( response_date.second === "00", 'Accurate preprocessed second' );
+					assert( response_date.timezone_offset === "-0500", 'Accurate preprocessed timezone_offset' );
+					assert( response_date.year.full === "2013", 'Accurate preprocessed year.full' );
+					assert( response_date.year.half === "13", 'Accurate preprocessed year.half' );
+
+					// Event Links
+					var response_event_link = response.events[0].links[0];
+					assert( response_event_link.publish_start.original === "2013-04-05T00:00:00-0400", 'Event link publish date exists')
+					assert( response_event_link.publish_end.original === "2013-08-09T07:00:00-0400", 'Event link publish date exists')
+					assert( html.indexOf('<li><a href="http://www.ticketmaster.com">Public Tickets</a></li>') >= 0, 'Event link in template')
+
 					done();
 				});
 


### PR DESCRIPTION
Publish dates were added to the [sparkart-services API](https://github.com/SparkartGroupInc/sparkart-services/pull/136) 6 months (!) ago so that they could be displayed to site visitors prior to the start of ticketing. We didn't use the Events/Event widgets on a site however until Keith Urban due to the API's performance & scalability issues. Sparkart.js handles date formatting by pre-processing API responses before they're passed to the template context for rendering. This step was missing for these dates. We should really be including these in the default template as well but I am deferring that work for an upcoming UX project that will redefine the default templates to be inline with their vision for the next generation of Sparkart fanclubs.

Can someone else please add tests? I made this change quickly hours before these widgets went live on the Keith Urban site.
