### PR TITLE
Pass fanclub links from endpoint to template contexts

### DIFF
--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -223,7 +223,7 @@ this.sparkart = {};
 			fanclub.customer = ( account_response )? account_response.customer: null;
 			fanclub.authentications = ( fanclub_response )? fanclub_response.fanclub.authentications: null;
 			fanclub.name = ( fanclub_response )? fanclub_response.fanclub.name: null;
-            fanclub.links = ( fanclub_response )? fanclub_response.fanclub.links: null;
+			fanclub.links = ( fanclub_response )? fanclub_response.fanclub.links: null;
 
 			if(fanclub.parameters.environment === "production") {
 				fanclub.tracking = fanclub_response.fanclub.tracking.production;

--- a/src/sparkart.js
+++ b/src/sparkart.js
@@ -223,6 +223,7 @@ this.sparkart = {};
 			fanclub.customer = ( account_response )? account_response.customer: null;
 			fanclub.authentications = ( fanclub_response )? fanclub_response.fanclub.authentications: null;
 			fanclub.name = ( fanclub_response )? fanclub_response.fanclub.name: null;
+            fanclub.links = ( fanclub_response )? fanclub_response.fanclub.links: null;
 
 			if(fanclub.parameters.environment === "production") {
 				fanclub.tracking = fanclub_response.fanclub.tracking.production;


### PR DESCRIPTION
The sparkart-services [fanclub endpoint](https://github.com/SparkartGroupInc/sparkart-services/blob/master/doc/api/fanclubs.md) provides an array of helpful links for a site's primary URL, any setup forums, etc. Sparkart.js doesn't pass the contents of this endpoint on as-is however, presumably to not pass along things like `status`. This simple update provides these links to templates for rendering and durable integration rather than horrible hardcoding. 
